### PR TITLE
Fix builds on glibc >= 2.38 (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All versions are tagged by the major Postgres version, plus an individual semver for this library itself.
 
+## 15-4.2.3   2023-07-07
+
+* Fix builds when compiling with `glibc >=  2.38` [#203](https://github.com/pganalyze/libpg_query/pull/203)
+* Deparser: Add support for COALESCE and other expressions in LIMIT clause [#199](https://github.com/pganalyze/libpg_query/pull/199)
+
 ## 15-4.2.2   2023-07-07
 
 * Deparser:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PG_VERSION = 15.1
 PG_VERSION_MAJOR = $(call word-dot,$(PG_VERSION),1)
 PROTOC_VERSION = 3.19.6
 
-VERSION = 4.2.2
+VERSION = 4.2.3
 VERSION_MAJOR = $(call word-dot,$(VERSION),1)
 VERSION_MINOR = $(call word-dot,$(VERSION),2)
 VERSION_PATCH = $(call word-dot,$(VERSION),3)
@@ -148,7 +148,8 @@ $(PGDIR):
 	echo "#undef USE_ARMV8_CRC32C" >> $(PGDIR)/src/include/pg_config.h
 	echo "#undef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK" >> $(PGDIR)/src/include/pg_config.h
 	# Ensure we don't fail on systems that have strchrnul support (FreeBSD and NetBSD)
-	echo "#if defined(__FreeBSD__) || defined(__NetBSD__)" >> $(PGDIR)/src/include/pg_config.h
+	echo "#include <stdlib.h>" >>  $(PGDIR)/src/include/pg_config.h
+	echo "#if defined(__FreeBSD__) || defined(__NetBSD__) || (defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38) || __GLIBC__ > 2))" >> $(PGDIR)/src/include/pg_config.h
 	echo "#define HAVE_STRCHRNUL" >> $(PGDIR)/src/include/pg_config.h
 	echo "#endif" >> $(PGDIR)/src/include/pg_config.h
 

--- a/src/postgres/include/pg_config.h
+++ b/src/postgres/include/pg_config.h
@@ -1032,6 +1032,7 @@
 #undef HAVE__GET_CPUID
 #undef USE_ARMV8_CRC32C
 #undef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#include <stdlib.h>
+#if defined(__FreeBSD__) || defined(__NetBSD__) || (defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38) || __GLIBC__ > 2))
 #define HAVE_STRCHRNUL
 #endif


### PR DESCRIPTION
* Fix builds on glibc >= 2.38

`glibc` now defines `strchrnul`, so we add a check to see if `glibc` is being used, and instead import the symbol if so.

* Bump version to 4.2.3

* Add note about PR #199 in 4.2.3 changelog